### PR TITLE
Use Matomo's name in namespaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "LGPL-3.0",
     "autoload": {
         "psr-4": {
-            "Piwik\\GithubSync\\": "src/"
+            "Matomo\\GithubSync\\": "src/"
         }
     },
     "require": {

--- a/github-sync.php
+++ b/github-sync.php
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-use Piwik\GithubSync\SyncCommand;
+use Matomo\GithubSync\SyncCommand;
 use Symfony\Component\Console\Application;
 
 require_once __DIR__ . '/vendor/autoload.php';

--- a/src/AbstractSynchronizer.php
+++ b/src/AbstractSynchronizer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Piwik\GithubSync;
+namespace Matomo\GithubSync;
 
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/AuthenticationRequiredException.php
+++ b/src/AuthenticationRequiredException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Piwik\GithubSync;
+namespace Matomo\GithubSync;
 
 class AuthenticationRequiredException extends \Exception
 {

--- a/src/Github.php
+++ b/src/Github.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Piwik\GithubSync;
+namespace Matomo\GithubSync;
 
 use Github\Client;
 use Github\Exception\RuntimeException;

--- a/src/LabelSynchronizer.php
+++ b/src/LabelSynchronizer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Piwik\GithubSync;
+namespace Matomo\GithubSync;
 
 use ArrayComparator\ArrayComparator;
 

--- a/src/MilestoneSynchronizer.php
+++ b/src/MilestoneSynchronizer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Piwik\GithubSync;
+namespace Matomo\GithubSync;
 
 use ArrayComparator\ArrayComparator;
 

--- a/src/SyncCommand.php
+++ b/src/SyncCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Piwik\GithubSync;
+namespace Matomo\GithubSync;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;


### PR DESCRIPTION
The namespaces was out-of-date, since the new Matomo's name.
I saw you didn't changed them in the main repository, so I made a different PR for the documentation (#12)

Cheers,
Thomas.