### PR TITLE
Use proper RuntimeException

### DIFF
--- a/src/LabelSynchronizer.php
+++ b/src/LabelSynchronizer.php
@@ -3,6 +3,7 @@
 namespace Piwik\GithubSync;
 
 use ArrayComparator\ArrayComparator;
+use Github\Exception\RuntimeException;
 
 /**
  * Synchronizes labels.
@@ -64,7 +65,7 @@ class LabelSynchronizer extends AbstractSynchronizer
             $this->github->createLabel($repository, $name, $color);
 
             $this->output->writeln('<info>Label created</info>');
-        } catch (AuthenticationRequiredException $e) {
+        } catch (RuntimeException $e) {
             // We show the error but don't stop the app
             $this->output->writeln(sprintf('<error>Skipped: %s</error>', $e->getMessage()));
         }
@@ -76,7 +77,7 @@ class LabelSynchronizer extends AbstractSynchronizer
             $this->github->deleteLabel($repository, $name);
 
             $this->output->writeln('<info>Label deleted</info>');
-        } catch (AuthenticationRequiredException $e) {
+        } catch (RuntimeException $e) {
             // We show the error but don't stop the app
             $this->output->writeln(sprintf('<error>Skipped: %s</error>', $e->getMessage()));
         }
@@ -88,7 +89,7 @@ class LabelSynchronizer extends AbstractSynchronizer
             $this->github->updateLabel($repository, $name, $newName, $color);
 
             $this->output->writeln('<info>Label updated</info>');
-        } catch (AuthenticationRequiredException $e) {
+        } catch (RuntimeException $e) {
             // We show the error but don't stop the app
             $this->output->writeln(sprintf('<error>Skipped: %s</error>', $e->getMessage()));
         }

--- a/src/MilestoneSynchronizer.php
+++ b/src/MilestoneSynchronizer.php
@@ -3,6 +3,7 @@
 namespace Piwik\GithubSync;
 
 use ArrayComparator\ArrayComparator;
+use Github\Exception\RuntimeException;
 
 /**
  * Synchronizes milestones.
@@ -47,7 +48,7 @@ class MilestoneSynchronizer extends AbstractSynchronizer
             $this->github->createMilestone($repository, $title, $state);
 
             $this->output->writeln('<info>Milestone created</info>');
-        } catch (AuthenticationRequiredException $e) {
+        } catch (RuntimeException $e) {
             // We show the error but don't stop the app
             $this->output->writeln(sprintf('<error>Skipped: %s</error>', $e->getMessage()));
         }
@@ -59,7 +60,7 @@ class MilestoneSynchronizer extends AbstractSynchronizer
             $this->github->deleteMilestone($repository, $milestone['number']);
 
             $this->output->writeln('<info>Milestone deleted</info>');
-        } catch (AuthenticationRequiredException $e) {
+        } catch (RuntimeException $e) {
             // We show the error but don't stop the app
             $this->output->writeln(sprintf('<error>Skipped: %s</error>', $e->getMessage()));
         }


### PR DESCRIPTION
The exception `AuthenticationRequiredException` will never be thrown by the GitHub-API library you're using. Instead, it will throw `RuntimeException`, so this is a simple fix to use that instead.

Before:
```
  [Github\Exception\RuntimeException]
  Repository was archived so is read-only.
```
and code stops running.

Now:
```
Skipped: Repository was archived so is read-only.
```
and code keeps running.